### PR TITLE
feat(privatelink): supports selector for kind VpcEndpointServiceResource to refer alb instance automatically

### DIFF
--- a/apis/privatelink/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/privatelink/v1alpha1/zz_generated.deepcopy.go
@@ -1158,6 +1158,16 @@ func (in *VpcEndpointServiceResourceInitParameters) DeepCopyInto(out *VpcEndpoin
 		*out = new(string)
 		**out = **in
 	}
+	if in.ResourceIDRef != nil {
+		in, out := &in.ResourceIDRef, &out.ResourceIDRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ResourceIDSelector != nil {
+		in, out := &in.ResourceIDSelector, &out.ResourceIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ResourceType != nil {
 		in, out := &in.ResourceType, &out.ResourceType
 		*out = new(string)
@@ -1294,6 +1304,16 @@ func (in *VpcEndpointServiceResourceParameters) DeepCopyInto(out *VpcEndpointSer
 		in, out := &in.ResourceID, &out.ResourceID
 		*out = new(string)
 		**out = **in
+	}
+	if in.ResourceIDRef != nil {
+		in, out := &in.ResourceIDRef, &out.ResourceIDRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ResourceIDSelector != nil {
+		in, out := &in.ResourceIDSelector, &out.ResourceIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ResourceType != nil {
 		in, out := &in.ResourceType, &out.ResourceType

--- a/apis/privatelink/v1alpha1/zz_generated.resolvers.go
+++ b/apis/privatelink/v1alpha1/zz_generated.resolvers.go
@@ -8,8 +8,9 @@ package v1alpha1
 
 import (
 	"context"
+	v1alpha12 "github.com/crossplane-contrib/provider-upjet-alibabacloud/apis/alb/v1alpha1"
 	v1alpha1 "github.com/crossplane-contrib/provider-upjet-alibabacloud/apis/ecs/v1alpha1"
-	v1alpha12 "github.com/crossplane-contrib/provider-upjet-alibabacloud/apis/ram/v1alpha1"
+	v1alpha13 "github.com/crossplane-contrib/provider-upjet-alibabacloud/apis/ram/v1alpha1"
 	v1alpha11 "github.com/crossplane-contrib/provider-upjet-alibabacloud/apis/vpc/v1alpha1"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
@@ -205,6 +206,22 @@ func (mg *VpcEndpointServiceResource) ResolveReferences(ctx context.Context, c c
 	var err error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ResourceID),
+		Extract:      reference.ExternalName(),
+		Reference:    mg.Spec.ForProvider.ResourceIDRef,
+		Selector:     mg.Spec.ForProvider.ResourceIDSelector,
+		To: reference.To{
+			List:    &v1alpha12.LoadBalancerList{},
+			Managed: &v1alpha12.LoadBalancer{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.ResourceID")
+	}
+	mg.Spec.ForProvider.ResourceID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.ResourceIDRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ServiceID),
 		Extract:      reference.ExternalName(),
 		Reference:    mg.Spec.ForProvider.ServiceIDRef,
@@ -219,6 +236,22 @@ func (mg *VpcEndpointServiceResource) ResolveReferences(ctx context.Context, c c
 	}
 	mg.Spec.ForProvider.ServiceID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.ServiceIDRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.ResourceID),
+		Extract:      reference.ExternalName(),
+		Reference:    mg.Spec.InitProvider.ResourceIDRef,
+		Selector:     mg.Spec.InitProvider.ResourceIDSelector,
+		To: reference.To{
+			List:    &v1alpha12.LoadBalancerList{},
+			Managed: &v1alpha12.LoadBalancer{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.ResourceID")
+	}
+	mg.Spec.InitProvider.ResourceID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.InitProvider.ResourceIDRef = rsp.ResolvedReference
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.ServiceID),
@@ -268,8 +301,8 @@ func (mg *VpcEndpointServiceUser) ResolveReferences(ctx context.Context, c clien
 		Reference:    mg.Spec.ForProvider.UserIDRef,
 		Selector:     mg.Spec.ForProvider.UserIDSelector,
 		To: reference.To{
-			List:    &v1alpha12.UserList{},
-			Managed: &v1alpha12.User{},
+			List:    &v1alpha13.UserList{},
+			Managed: &v1alpha13.User{},
 		},
 	})
 	if err != nil {
@@ -300,8 +333,8 @@ func (mg *VpcEndpointServiceUser) ResolveReferences(ctx context.Context, c clien
 		Reference:    mg.Spec.InitProvider.UserIDRef,
 		Selector:     mg.Spec.InitProvider.UserIDSelector,
 		To: reference.To{
-			List:    &v1alpha12.UserList{},
-			Managed: &v1alpha12.User{},
+			List:    &v1alpha13.UserList{},
+			Managed: &v1alpha13.User{},
 		},
 	})
 	if err != nil {

--- a/apis/privatelink/v1alpha1/zz_vpcendpointserviceresource_types.go
+++ b/apis/privatelink/v1alpha1/zz_vpcendpointserviceresource_types.go
@@ -19,7 +19,16 @@ type VpcEndpointServiceResourceInitParameters struct {
 	DryRun *bool `json:"dryRun,omitempty" tf:"dry_run,omitempty"`
 
 	// The service resource ID.
+	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-upjet-alibabacloud/apis/alb/v1alpha1.LoadBalancer
 	ResourceID *string `json:"resourceId,omitempty" tf:"resource_id,omitempty"`
+
+	// Reference to a LoadBalancer in alb to populate resourceId.
+	// +kubebuilder:validation:Optional
+	ResourceIDRef *v1.Reference `json:"resourceIdRef,omitempty" tf:"-"`
+
+	// Selector for a LoadBalancer in alb to populate resourceId.
+	// +kubebuilder:validation:Optional
+	ResourceIDSelector *v1.Selector `json:"resourceIdSelector,omitempty" tf:"-"`
 
 	// Service resource type, value:
 	ResourceType *string `json:"resourceType,omitempty" tf:"resource_type,omitempty"`
@@ -76,8 +85,17 @@ type VpcEndpointServiceResourceParameters struct {
 	Region *string `json:"region,omitempty" tf:"-"`
 
 	// The service resource ID.
+	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-upjet-alibabacloud/apis/alb/v1alpha1.LoadBalancer
 	// +kubebuilder:validation:Optional
 	ResourceID *string `json:"resourceId,omitempty" tf:"resource_id,omitempty"`
+
+	// Reference to a LoadBalancer in alb to populate resourceId.
+	// +kubebuilder:validation:Optional
+	ResourceIDRef *v1.Reference `json:"resourceIdRef,omitempty" tf:"-"`
+
+	// Selector for a LoadBalancer in alb to populate resourceId.
+	// +kubebuilder:validation:Optional
+	ResourceIDSelector *v1.Selector `json:"resourceIdSelector,omitempty" tf:"-"`
 
 	// Service resource type, value:
 	// +kubebuilder:validation:Optional
@@ -137,7 +155,6 @@ type VpcEndpointServiceResourceStatus struct {
 type VpcEndpointServiceResource struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.resourceId) || (has(self.initProvider) && has(self.initProvider.resourceId))",message="spec.forProvider.resourceId is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.resourceType) || (has(self.initProvider) && has(self.initProvider.resourceType))",message="spec.forProvider.resourceType is a required parameter"
 	Spec   VpcEndpointServiceResourceSpec   `json:"spec"`
 	Status VpcEndpointServiceResourceStatus `json:"status,omitempty"`

--- a/config/privatelink/config.go
+++ b/config/privatelink/config.go
@@ -38,6 +38,13 @@ func Configure(p *config.Provider) {
 		r.References["service_id"] = config.Reference{
 			TerraformName: "alicloud_privatelink_vpc_endpoint_service",
 		}
+		// Currently only alb is supported caused by the limitation of crossplane. More load balancer types if want to
+		// be supported, there are two ways:
+		// 1. waiting for crossplane supports querying and filtering the specified resource, see https://github.com/crossplane/crossplane/blob/main/design/design-doc-observe-only-resources.md#querying-and-filtering
+		// 2. implement a new kind, like VpcEndpointServiceResourceSlb, VpcEndpointServiceResourceNlb and so on.
+		r.References["resource_id"] = config.Reference{
+			TerraformName: "alicloud_alb_load_balancer",
+		}
 	})
 	p.AddResourceConfigurator("alicloud_privatelink_vpc_endpoint_service_user", func(r *config.Resource) {
 		r.ShortGroup = string(common.PRIVATELINK)

--- a/examples-generated/privatelink/v1alpha1/vpcendpointconnection.yaml
+++ b/examples-generated/privatelink/v1alpha1/vpcendpointconnection.yaml
@@ -70,7 +70,9 @@ metadata:
 spec:
   forProvider:
     region: cn-beijing
-    resourceId: ${alicloud_slb_load_balancer.example.id}
+    resourceIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
     resourceType: slb
     serviceIdSelector:
       matchLabels:

--- a/examples-generated/privatelink/v1alpha1/vpcendpointserviceresource.yaml
+++ b/examples-generated/privatelink/v1alpha1/vpcendpointserviceresource.yaml
@@ -9,7 +9,9 @@ metadata:
 spec:
   forProvider:
     region: cn-beijing
-    resourceId: ${alicloud_slb_load_balancer.example.id}
+    resourceIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
     resourceType: slb
     serviceIdSelector:
       matchLabels:

--- a/examples-generated/privatelink/v1alpha1/vpcendpointzone.yaml
+++ b/examples-generated/privatelink/v1alpha1/vpcendpointzone.yaml
@@ -70,7 +70,9 @@ metadata:
 spec:
   forProvider:
     region: cn-beijing
-    resourceId: ${alicloud_slb_load_balancer.example.id}
+    resourceIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
     resourceType: slb
     serviceIdSelector:
       matchLabels:

--- a/examples/privatelink/v1alpha1/vpcendpointserviceresource.yaml
+++ b/examples/privatelink/v1alpha1/vpcendpointserviceresource.yaml
@@ -8,11 +8,14 @@ metadata:
   name: example-for-service-resource
 spec:
   forProvider:
-    resourceId: ${alicloud_slb_load_balancer.example.id}
-    resourceType: slb
+    resourceIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: vpcendpointserviceresource
+    resourceType: alb
     serviceIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example-for-service-resource
+    zoneId: cn-beijing-f
 
 ---
 
@@ -28,7 +31,9 @@ spec:
   forProvider:
     securityGroupRefs:
     - name: example-for-service-resource
-    serviceId: ${alicloud_privatelink_vpc_endpoint_service.example.id}
+    serviceIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-for-service-resource
     vpcEndpointName: crossplane-example
     vpcIdSelector:
       matchLabels:
@@ -49,7 +54,45 @@ spec:
     autoAcceptConnection: false
     connectBandwidth: 103
     serviceDescription: crossplane-example
+    serviceResourceType: alb
 
+---
+
+apiVersion: alb.alibabacloud.crossplane.io/v1alpha1
+kind: LoadBalancer
+metadata:
+  annotations:
+    meta.upbound.io/example-id: alb/v1alpha1/vpcendpointserviceresource
+  labels:
+    testing.upbound.io/example-name: vpcendpointserviceresource
+  name: vpcendpointserviceresource
+spec:
+  forProvider:
+    addressAllocatedMode: Fixed
+    addressType: Internet
+    loadBalancerBillingConfig:
+      - payType: PayAsYouGo
+    loadBalancerEdition: Basic
+    loadBalancerName: crossplane-example-for-vpcendpointserviceresource
+    modificationProtectionConfig:
+      - status: NonProtection
+    region: cn-beijing
+    #    resourceGroupId: ${data.alicloud_resource_manager_resource_groups.default.groups.0.id}
+    tags:
+      Created: TF
+    vpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-for-service-resource
+    zoneMappings:
+    - vswitchIdSelector:
+        matchLabels:
+          testing.upbound.io/example-name: example-for-service-resource-1
+      zoneId: cn-beijing-f
+    - vswitchIdSelector:
+        matchLabels:
+          testing.upbound.io/example-name: example-for-service-resource-2
+      zoneId: cn-beijing-g
+        
 ---
 
 apiVersion: ecs.alibabacloud.crossplane.io/v1alpha1
@@ -62,6 +105,7 @@ metadata:
   name: example-for-service-resource
 spec:
   forProvider:
+    region: cn-beijing
     securityGroupName: crossplane-example
     vpcIdSelector:
       matchLabels:
@@ -79,7 +123,8 @@ metadata:
   name: example-for-service-resource
 spec:
   forProvider:
-    cidrBlock: 10.0.0.0/8
+    region: cn-beijing
+    cidrBlock: 10.4.0.0/16
     vpcName: crossplane-example
 
 ---
@@ -88,15 +133,36 @@ apiVersion: vpc.alibabacloud.crossplane.io/v1alpha1
 kind: Vswitch
 metadata:
   annotations:
-    meta.upbound.io/example-id: privatelink/v1alpha1/vpcendpointserviceresource
+    meta.upbound.io/example-id: alb/v1alpha1/loadbalancer
   labels:
-    testing.upbound.io/example-name: example-for-service-resource
-  name: example-for-service-resource
+    testing.upbound.io/example-name: example-for-service-resource-1
+  name: example-for-service-resource-1
 spec:
   forProvider:
-    cidrBlock: 10.1.0.0/16
+    cidrBlock: 10.4.1.0/24
+    region: cn-beijing
     vpcIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example-for-service-resource
-    vswitchName: crossplane-example
-    zoneId: cn-beijing-h
+    vswitchName: crossplane-example_1
+    zoneId: cn-beijing-f
+
+---
+
+apiVersion: vpc.alibabacloud.crossplane.io/v1alpha1
+kind: Vswitch
+metadata:
+  annotations:
+    meta.upbound.io/example-id: alb/v1alpha1/loadbalancer
+  labels:
+    testing.upbound.io/example-name: example-for-service-resource-2
+  name: example-for-service-resource-2
+spec:
+  forProvider:
+    cidrBlock: 10.4.2.0/24
+    region: cn-beijing
+    vpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-for-service-resource
+    vswitchName: crossplane-example_2
+    zoneId: cn-beijing-g

--- a/package/crds/privatelink.alibabacloud.crossplane.io_vpcendpointserviceresources.yaml
+++ b/package/crds/privatelink.alibabacloud.crossplane.io_vpcendpointserviceresources.yaml
@@ -85,6 +85,80 @@ spec:
                   resourceId:
                     description: The service resource ID.
                     type: string
+                  resourceIdRef:
+                    description: Reference to a LoadBalancer in alb to populate resourceId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  resourceIdSelector:
+                    description: Selector for a LoadBalancer in alb to populate resourceId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   resourceType:
                     description: 'Service resource type, value:'
                     type: string
@@ -192,6 +266,80 @@ spec:
                   resourceId:
                     description: The service resource ID.
                     type: string
+                  resourceIdRef:
+                    description: Reference to a LoadBalancer in alb to populate resourceId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  resourceIdSelector:
+                    description: Selector for a LoadBalancer in alb to populate resourceId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   resourceType:
                     description: 'Service resource type, value:'
                     type: string
@@ -447,10 +595,6 @@ spec:
             - forProvider
             type: object
             x-kubernetes-validations:
-            - message: spec.forProvider.resourceId is a required parameter
-              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
-                || ''Update'' in self.managementPolicies) || has(self.forProvider.resourceId)
-                || (has(self.initProvider) && has(self.initProvider.resourceId))'
             - message: spec.forProvider.resourceType is a required parameter
               rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                 || ''Update'' in self.managementPolicies) || has(self.forProvider.resourceType)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
feat(privatelink): supports selector for kind VpcEndpointServiceResource to refer alb instance automatically

I have:

- [ x] Read and followed Crossplane's [contribution process](https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md).
- [ x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
running the following commands manually:

`kubectl apply -f examples/privatelink/v1alpha1/vpcendpointserviceresource.yaml`
`kubectl get managed`
`kubectl delete -f examples/privatelink/v1alpha1/vpcendpointserviceresource.yaml`
