### PR TITLE
dont publish to registry in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,3 @@ jobs:
         with:
           name: output
           path: _output/**
-
-      - name: Publish Artifacts
-        if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != ''
-        run: make publish BRANCH_NAME=${GITHUB_REF##*/}

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ GO_SUBDIRS += cmd internal apis
 # Setup Kubernetes tools
 
 KIND_VERSION = v0.26.0
-UP_VERSION = v0.38.0
+UP_VERSION = v0.40.3
 UP_CHANNEL = stable
 #UPTEST_VERSION = v0.13.1
 UPTEST_VERSION = v1.1.2

--- a/cluster/images/provider-upjet-alibabacloud/Makefile
+++ b/cluster/images/provider-upjet-alibabacloud/Makefile
@@ -66,7 +66,6 @@ batch-process: $(UP)
 	@$(INFO) Batch processing smaller provider packages for: "$(SUBPACKAGES)"
 	@mkdir -p "$(XPKG_OUTPUT_DIR)/$(PLATFORM)" && \
 	$(UP) xpkg batch --smaller-providers "$$(tr ' ' ',' <<< "$(SUBPACKAGES)")" \
-		--verbose \
 		--family-base-image $(BUILD_REGISTRY)/$(PROJECT_NAME) \
 		--platform $(BATCH_PLATFORMS) \
 		--provider-name $(PROJECT_NAME) \


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

There is a dedicated workflow/action for publishing: https://github.com/crossplane-contrib/provider-upjet-alibabacloud/actions/workflows/publish-provider-packages.yaml

CI does not need to configure this, which follows how AWS, GCP, Azure, and others configure family builds.

I opted to keep the binaries being uploaded to GitHub artifacts for now.

I have:

- [ ] Read and followed Crossplane's [contribution process](https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md).
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
