### PR TITLE
Update to go 1.26.4, golangci-lint to 2.12.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       # We could run 'make lint' but we prefer this action because it leaves
       # 'annotations' (i.e. it comments on PRs to point out linter violations).
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: ${{ env.GOLANGCI_VERSION }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   # Common versions
   GO_VERSION: '1.26.4'
-  GOLANGCI_VERSION: 'v1.64.8'
+  GOLANGCI_VERSION: 'v2.12.2'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 
   # Common users. We can't run a step 'if secrets.XXX != ""' but we can run a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.26.4'
   GOLANGCI_VERSION: 'v1.64.8'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,7 +9,7 @@ on:
     types: [created]
 
 env:
-  GO_VERSION: "1.24"
+  GO_VERSION: "1.26.4"
 
 jobs:
   check-permissions:

--- a/.github/workflows/publish-provider-packages.yaml
+++ b/.github/workflows/publish-provider-packages.yaml
@@ -21,7 +21,7 @@ on:
         required: false
       go-version:
         description: 'Go version to use if building needs to be done'
-        default: '1.24'
+        default: '1.26.4'
         required: false
 
 jobs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,4 @@
-# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
-#
-# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>#
 
 version: "2"
 
@@ -28,9 +26,6 @@ linters:
     - unused       # This remains separate in v2
     - misspell
     - nakedret
-
-  presets:
-    - bugs
 
   settings:
     errcheck:
@@ -188,8 +183,7 @@ formatters:
       # put imports beginning with prefix after 3rd-party packages;
       # it's a comma-separated list of prefixes
       local-prefixes:
-        - github.com/upbound/provider-aws/v2
-
+        - github.com/crossplane-contrib/provider-alibabacloud
   exclusions:
     paths:
       - "zz_.*go$"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,173 +1,200 @@
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+version: "2"
+
 run:
   timeout: 90m
   concurrency: 1
 
 output:
-  print-linter-name: true
-  show-stats: true
-
-linters-settings:
-  errcheck:
-    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
-    # default is false: such cases aren't reported by default.
-    check-type-assertions: false
-
-    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
-    # default is false: such cases aren't reported by default.
-    check-blank: false
-
-    exclude-functions:
-      - io/ioutil.ReadFile
-      - io/ioutil.ReadDir
-      - io/ioutil.ReadAll
-
-  govet:
-    # report about shadowed variables
-    enable:
-      - shadow
-
-  revive:
-    # confidence for issues, default is 0.8
-    confidence: 0.8
-
-  gofmt:
-    # simplify code: gofmt with `-s` option, true by default
-    simplify: true
-
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: crossplane-contrib/provider-upjet-alibabacloud
-
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 10
-
-  dupl:
-    # tokens count to trigger issue, 150 by default
-    threshold: 100
-
-  goconst:
-    # minimal length of string constant, 3 by default
-    min-len: 3
-    # minimal occurrences count to trigger, 3 by default
-    min-occurrences: 5
-
-  lll:
-    # tab width in spaces. Default to 1.
-    tab-width: 1
-
-  unparam:
-    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
-    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
-
-  nakedret:
-    # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
-    max-func-lines: 30
-
-  prealloc:
-    # XXX: we don't recommend using this linter before doing performance profiling.
-    # For most programs usage of prealloc will be a premature optimization.
-
-    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
-    # True by default.
-    simple: true
-    range-loops: true # Report preallocation suggestions on range loops, true by default
-    for-loops: false # Report preallocation suggestions on for loops, false by default
-
-  gocritic:
-    # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint` run to see all tags and checks.
-    # Empty list by default. See https://github.com/go-critic/go-critic#usage -> section "Tags".
-    enabled-tags:
-      - performance
-
-    settings: # settings passed to gocritic
-      captLocal: # must be valid enabled check name
-        paramsOnly: true
-      rangeValCopy:
-        sizeThreshold: 32
+  formats:
+    text:
+      path: stdout
+      print-linter-name: true
 
 linters:
+  default: none
   enable:
+    - errcheck
     - govet
     - gocyclo
     - gocritic
-    - goconst
-#    - goimports
-    - gofmt  # We enable this as well as goimports for its simplify mode.
-    - gosimple
     - prealloc
     - revive
-    - staticcheck
+    - staticcheck  # In v2, gosimple and stylecheck are merged into staticcheck
     - unconvert
-    - unused
+    - unused       # This remains separate in v2
     - misspell
     - nakedret
 
   presets:
     - bugs
-    - unused
-  fast: false
+
+  settings:
+    errcheck:
+      # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
+      # default is false: such cases aren't reported by default.
+      check-type-assertions: false
+
+      # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
+      # default is false: such cases aren't reported by default.
+      check-blank: false
+
+      exclude-functions:
+        - io/ioutil.ReadFile
+        - io/ioutil.ReadDir
+        - io/ioutil.ReadAll
+
+    govet:
+      # In v2, check-shadowing is deprecated. Use govet.enable: [shadow] to enable shadow checking
+      # check-shadowing: false  # Removed - was false anyway
+      disable:
+        - shadow
+
+    revive:
+      # confidence for issues, default is 0.8
+      confidence: 0.8
+
+    gocyclo:
+      # minimal code complexity to report, 30 by default (but we recommend 10-20)
+      min-complexity: 10
+
+    dupl:
+      # tokens count to trigger issue, 150 by default
+      threshold: 100
+
+    goconst:
+      # minimal length of string constant, 3 by default
+      min-len: 3
+      # minimal occurrences count to trigger, 3 by default
+      min-occurrences: 5
+
+    lll:
+      # tab width in spaces. Default to 1.
+      tab-width: 1
+
+    unparam:
+      # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
+      # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
+      # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
+      # with golangci-lint call it on a directory with the changed file.
+      check-exported: false
+
+    nakedret:
+      # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
+      max-func-lines: 30
+
+    prealloc:
+      # XXX: we don't recommend using this linter before doing performance profiling.
+      # For most programs usage of prealloc will be a premature optimization.
+
+      # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
+      # True by default.
+      simple: true
+      range-loops: true # Report preallocation suggestions on range loops, true by default
+      for-loops: false # Report preallocation suggestions on for loops, false by default
+
+    gocritic:
+      # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint` run to see all tags and checks.
+      # Empty list by default. See https://github.com/go-critic/go-critic#usage -> section "Tags".
+      enabled-tags:
+        - performance
+
+      settings: # settings passed to gocritic
+        captLocal: # must be valid enabled check name
+          paramsOnly: true
+        rangeValCopy:
+          sizeThreshold: 32
+
+  exclusions:
+    paths:
+      - "zz_.*go$"
+
+    rules:
+      # some group names we have (like "hdinsight") make this linter
+      # unhappy, so just disable the "misspell" linter on generated files.
+      - path: zz_.+\.go$
+        linters:
+          - misspell
+
+      # Exclude some linters from running on tests files.
+      - path: _test(ing)?\.go
+        linters:
+          - gocyclo
+          - errcheck
+          - dupl
+          - gosec
+          - scopelint
+          - unparam
+
+      # Ease some gocritic warnings on test files.
+      - path: _test\.go
+        text: "(unnamedResult|exitAfterDefer)"
+        linters:
+          - gocritic
+
+      # These are performance optimisations rather than style issues per se.
+      # They warn when function arguments or range values copy a lot of memory
+      # rather than using a pointer.
+      - text: "(hugeParam|rangeValCopy):"
+        linters:
+          - gocritic
+
+      # This "TestMain should call os.Exit to set exit code" warning is not clever
+      # enough to notice that we call a helper method that calls os.Exit.
+      - text: "SA3000:"
+        linters:
+          - staticcheck
+
+      - text: "k8s.io/api/core/v1"
+        linters:
+          - goimports
+
+      # This is a "potential hardcoded credentials" warning. It's triggered by
+      # any variable with 'secret' in the same, and thus hits a lot of false
+      # positives in Kubernetes land where a Secret is an object type.
+      - text: "G101:"
+        linters:
+          - gosec
+          - gas
+
+      # This is an 'errors unhandled' warning that duplicates errcheck.
+      - text: "G104:"
+        linters:
+          - gosec
+          - gas
+
+      # mgr.GetEventRecorderFor is deprecated at controller-runtime
+      # in favor of mgr.GetEventRecorder.
+      # Suppress until crossplane-runtime adapts
+      - path: internal/controller/
+        text: "SA1019:.*GetEventRecorderFor is deprecated"
+        linters:
+          - staticcheck
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
+  settings:
+    gofmt:
+      # simplify code: gofmt with `-s` option, true by default
+      simplify: true
+
+    goimports:
+      # put imports beginning with prefix after 3rd-party packages;
+      # it's a comma-separated list of prefixes
+      local-prefixes:
+        - github.com/upbound/provider-aws/v2
+
+  exclusions:
+    paths:
+      - "zz_.*go$"
 
 issues:
-  # Excluding configuration per-path and per-linter
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test(ing)?\.go
-      linters:
-        - gocyclo
-        - errcheck
-        - dupl
-        - gosec
-        - scopelint
-        - unparam
-
-    # Ease some gocritic warnings on test files.
-    - path: _test\.go
-      text: "(unnamedResult|exitAfterDefer)"
-      linters:
-        - gocritic
-
-    # These are performance optimisations rather than style issues per se.
-    # They warn when function arguments or range values copy a lot of memory
-    # rather than using a pointer.
-    - text: "(hugeParam|rangeValCopy):"
-      linters:
-        - gocritic
-
-    # This "TestMain should call os.Exit to set exit code" warning is not clever
-    # enough to notice that we call a helper method that calls os.Exit.
-    - text: "SA3000:"
-      linters:
-        - staticcheck
-
-    - text: "k8s.io/api/core/v1"
-      linters:
-        - goimports
-
-    # This is a "potential hardcoded credentials" warning. It's triggered by
-    # any variable with 'secret' in the same, and thus hits a lot of false
-    # positives in Kubernetes land where a Secret is an object type.
-    - text: "G101:"
-      linters:
-        - gosec
-        - gas
-
-    # This is an 'errors unhandled' warning that duplicates errcheck.
-    - text: "G104:"
-      linters:
-        - gosec
-        - gas
-
-  # Independently from option `exclude` we use default exclude patterns,
-  # it can be disabled by this option. To list all
-  # excluded by default patterns execute `golangci-lint run --help`.
-  # Default value for this option is true.
-  exclude-use-default: false
-
   # Show only new issues: if there are unstaged changes or untracked files,
   # only those changes are analyzed, else only changes in HEAD~ are analyzed.
   # It's a super-useful option for integration of golangci-lint into existing

--- a/config/ack/config.go
+++ b/config/ack/config.go
@@ -1,8 +1,9 @@
 package ack
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/ackone/config.go
+++ b/config/ackone/config.go
@@ -1,8 +1,9 @@
 package ackone
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/alb/config.go
+++ b/config/alb/config.go
@@ -1,8 +1,9 @@
 package alb
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/alidns/config.go
+++ b/config/alidns/config.go
@@ -1,8 +1,9 @@
 package alidns
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/cdn/config.go
+++ b/config/cdn/config.go
@@ -1,8 +1,9 @@
 package cdn
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/cloudmonitorservice/config.go
+++ b/config/cloudmonitorservice/config.go
@@ -1,8 +1,9 @@
 package cloudmonitorservice
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/ecs/config.go
+++ b/config/ecs/config.go
@@ -1,8 +1,9 @@
 package ecs
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/fcv3/config.go
+++ b/config/fcv3/config.go
@@ -1,8 +1,9 @@
 package fcv3
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/kms/config.go
+++ b/config/kms/config.go
@@ -1,8 +1,9 @@
 package kms
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/messageservice/config.go
+++ b/config/messageservice/config.go
@@ -1,8 +1,9 @@
 package messageservice
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/oos/config.go
+++ b/config/oos/config.go
@@ -1,8 +1,9 @@
 package oos
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/oss/config.go
+++ b/config/oss/config.go
@@ -1,8 +1,9 @@
 package oss
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/polardb/config.go
+++ b/config/polardb/config.go
@@ -1,8 +1,9 @@
 package polardb
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/privatelink/config.go
+++ b/config/privatelink/config.go
@@ -1,8 +1,9 @@
 package privatelink
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/provider.go
+++ b/config/provider.go
@@ -11,6 +11,8 @@ import (
 	"github.com/crossplane-contrib/provider-alibabacloud/config/fcv3"
 	"github.com/crossplane-contrib/provider-alibabacloud/config/slb"
 
+	"github.com/crossplane/upjet/pkg/registry/reference"
+
 	"github.com/crossplane-contrib/provider-alibabacloud/config/ack"
 	"github.com/crossplane-contrib/provider-alibabacloud/config/ackone"
 	"github.com/crossplane-contrib/provider-alibabacloud/config/alb"
@@ -30,7 +32,6 @@ import (
 	"github.com/crossplane-contrib/provider-alibabacloud/config/tair"
 	"github.com/crossplane-contrib/provider-alibabacloud/config/vpc"
 	"github.com/crossplane-contrib/provider-alibabacloud/hack"
-	"github.com/crossplane/upjet/pkg/registry/reference"
 
 	ujconfig "github.com/crossplane/upjet/pkg/config"
 )

--- a/config/quotas/config.go
+++ b/config/quotas/config.go
@@ -1,8 +1,9 @@
 package quotas
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/slb/config.go
+++ b/config/slb/config.go
@@ -1,8 +1,9 @@
 package slb
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/tair/config.go
+++ b/config/tair/config.go
@@ -1,8 +1,9 @@
 package tair
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/config/vpc/config.go
+++ b/config/vpc/config.go
@@ -1,8 +1,9 @@
 package vpc
 
 import (
-	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/config/common"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane-contrib/provider-alibabacloud
 
-go 1.24.1
+go 1.26.4
 
 require (
 	dario.cat/mergo v1.0.1

--- a/internal/clients/alibabacloud.go
+++ b/internal/clients/alibabacloud.go
@@ -10,10 +10,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/crossplane-contrib/provider-alibabacloud/internal/version"
 	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/crossplane-contrib/provider-alibabacloud/internal/version"
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pkg/errors"


### PR DESCRIPTION


### Description of your changes

- Update go to 1.26.4
- Upate golangci-lint to 2.12.2
- Update golangci-lint configuration to follow other upjet provider settings. 
- Update imports to match `goimports` linter rules

I have:

- [x] Read and followed Crossplane's [contribution process](https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md).
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
